### PR TITLE
feat: add app build

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -1,0 +1,48 @@
+name: Build Signed App Bundle
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch: # Allows manual trigger from the Actions tab
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+
+      - name: Install Dependencies
+        run: flutter pub get
+
+      - name: Decode Keystore
+        run: |
+          echo "${{ secrets.ANDROID_KEYSTORE_BASE64 }}" | base64 --decode > android/app/upload-keystore.jks
+
+      - name: Build App Bundle
+        run: |
+          # The --build-number uses the unique GitHub Action run count
+          flutter build appbundle --release --build-number=${{ github.run_number }}
+        env:
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tamil-via-hindi-release
+          path: build/app/outputs/bundle/release/app-release.aab
+          if-no-files-found: error

--- a/tamil_setu/android/app/build.gradle.kts
+++ b/tamil_setu/android/app/build.gradle.kts
@@ -19,11 +19,21 @@ android {
         jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
+    // 1. Add this signingConfigs block BEFORE the buildTypes block
+    signingConfigs {
+        create("release") {
+            // This refers to the file created in your GitHub Action step
+            storeFile = file("upload-keystore.jks")
+            
+            // These read the secrets from GitHub Environment Variables
+            storePassword = System.getenv("ANDROID_KEYSTORE_PASSWORD")
+            keyAlias = System.getenv("ANDROID_KEY_ALIAS")
+            keyPassword = System.getenv("ANDROID_KEY_PASSWORD")
+        }
+    }
+
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.tamil_setu"
-        // You can update the following values to match your application needs.
-        // For more information, see: https://flutter.dev/to/review-gradle-config.
+        applicationId = "com.boldesi.tamil_via_hindi"
         minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
@@ -32,9 +42,14 @@ android {
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            // 2. Change this to use the "release" config we just created
+            signingConfig = signingConfigs.getByName("release")
+            
+            isMinifyEnabled = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
         }
     }
 }


### PR DESCRIPTION
This pull request introduces a CI/CD workflow for building and signing the Android app bundle using GitHub Actions, and updates the Gradle configuration to support secure release signing with secrets. The changes automate the build process, ensure the app is signed with a release keystore, and improve the security and reliability of the release pipeline.

**CI/CD Automation and Secure Release Signing:**

* Added a new GitHub Actions workflow (`.github/workflows/build_and_release.yml`) that checks out the code, sets up Java and Flutter, installs dependencies, decodes the release keystore from a secret, builds a signed app bundle using a unique build number, and uploads the artifact for distribution.

**Gradle Configuration Updates:**

* Created a `signingConfigs` block in `tamil_setu/android/app/build.gradle.kts` to define a secure release signing configuration that reads keystore credentials from environment variables (GitHub secrets).
* Updated the `release` build type to use the new `release` signing config instead of the debug config, enabled code minification, and added ProGuard configuration for optimized release builds.
* Changed the `applicationId` in the Gradle config to `com.boldesi.tamil_via_hindi` to uniquely identify the app.