### PR TITLE
Enable user access to leaderboard

### DIFF
--- a/tamil_setu/firestore.rules
+++ b/tamil_setu/firestore.rules
@@ -25,7 +25,8 @@ service cloud.firestore {
     }
 
     match /users/{userId} {
-      allow read: if isOwner(userId);
+      // Any signed-in user may read user documents (required for leaderboard queries).
+      allow read: if isSignedIn();
       allow create, update: if isOwner(userId) && validUserStats();
       allow delete: if false;
     }


### PR DESCRIPTION
This pull request updates the Firestore security rules to allow broader access for reading user documents, which is necessary for leaderboard queries. Now, any signed-in user can read user documents, while write permissions remain restricted to the document owner.

Access control changes:

* Updated the `read` rule in the `/users/{userId}` match block of `firestore.rules` to allow any signed-in user to read user documents, instead of restricting reads to only the owner. This supports leaderboard functionality that requires access to multiple users' data.